### PR TITLE
Fix package holding animation

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,0 +1,46 @@
+function PickupPackage()
+    local ped = GetPlayerPed(-1)
+    local pos = GetEntityCoords(ped, true)
+    
+    -- Use the correct carrying animation
+    RequestAnimDict("anim@heists@box_carry@")
+    while (not HasAnimDictLoaded("anim@heists@box_carry@")) do
+        Citizen.Wait(7)
+    end
+    
+    -- Use the walking animation instead of idle for proper carrying
+    TaskPlayAnim(ped, "anim@heists@box_carry@", "walk", 8.0, -8.0, -1, 49, 0, false, false, false)
+    
+    local model = GetHashKey("prop_cs_cardbox_01")
+    RequestModel(model)
+    while not HasModelLoaded(model) do Citizen.Wait(0) end
+    
+    local object = CreateObject(model, pos.x, pos.y, pos.z, true, true, true)
+    AttachEntityToEntity(object, ped, GetPedBoneIndex(ped, 57005), 0.05, 0.1, -0.3, 300.0, 250.0, 20.0, true, true, false, true, 1, true)
+    carryPackage = object
+    
+    -- Keep the animation playing while carrying
+    Citizen.CreateThread(function()
+        while carryPackage ~= nil do
+            if not IsEntityPlayingAnim(ped, "anim@heists@box_carry@", "walk", 3) then
+                TaskPlayAnim(ped, "anim@heists@box_carry@", "walk", 8.0, -8.0, -1, 49, 0, false, false, false)
+            end
+            Citizen.Wait(1000)
+        end
+    end)
+end
+
+function DropPackage()
+    local ped = GetPlayerPed(-1)
+    
+    -- Stop the carrying animation
+    StopAnimTask(ped, "anim@heists@box_carry@", "walk", 1.0)
+    ClearPedTasks(ped)
+    
+    -- Remove the package
+    if carryPackage ~= nil then
+        DetachEntity(carryPackage, true, true)
+        DeleteObject(carryPackage)
+        carryPackage = nil
+    end
+end


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Improve box carrying animation to correctly display the player holding and transporting packages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous animation for picking up a box was incorrect, making the player appear to hold only one box without the proper carrying posture. This PR updates the `PickupPackage` function to use the `walk` animation with appropriate flags (`49`) and ensures the animation persists while carrying. It also refines `DropPackage` for a cleaner animation stop.

---

[Open in Web](https://cursor.com/agents?id=bc-de2ebc5b-4dc6-48cc-9479-d4d68dbb4084) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-de2ebc5b-4dc6-48cc-9479-d4d68dbb4084) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)